### PR TITLE
Disable the idle timer whilst updating

### DIFF
--- a/Crazyflie client/BootloaderViewController.swift
+++ b/Crazyflie client/BootloaderViewController.swift
@@ -29,6 +29,8 @@ class BootloaderViewController : UIViewController {
     // MARK: - UI handling
     
     override func viewDidLoad() {
+        super.viewDidLoad()
+        
         //_closeButton.layer.borderColor = [_closeButton tintColor].CGColor;
         self.closeButton.layer.borderWidth = 1
         self.closeButton.layer.cornerRadius = 4
@@ -42,11 +44,19 @@ class BootloaderViewController : UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIApplication.shared.isIdleTimerDisabled = true
+        
         self.state = .idle;
         
         self.progressIndicator.startAnimating()
         
         self.fetchFirmware();
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        UIApplication.shared.isIdleTimerDisabled = false
     }
     
     var state:State = .idle {


### PR DESCRIPTION
I got a Crazyflie for Christmas, did an update and my phone auto locked during the update. I'm an iOS developer pretty excited to get involved in this project so I've written a quick fix.

Commit message:
```
The idle timer causes the system to sleep based on the user’s Auto-Lock duration.

If a user has set a short Auto-Lock duration this could disrupt an update.

Applied on viewDidAppear / viewDidDisapear for simplicity.
```