### PR TITLE
Fix settings for custom control sensitivities

### DIFF
--- a/Crazyflie client/Settings.swift
+++ b/Crazyflie client/Settings.swift
@@ -200,11 +200,7 @@ final class Settings {
             return _pitchRate
         }
         set {
-            if newValue < minPitchRate {
-                _pitchRate = minPitchRate
-            } else if newValue > maxPitchRate {
-                _pitchRate = maxPitchRate
-            }
+            _pitchRate = min(max(newValue, minPitchRate), maxPitchRate)
         }
     }
     
@@ -213,11 +209,7 @@ final class Settings {
             return _maxThrust
         }
         set {
-            if newValue < minThrustRate {
-                _maxThrust = minThrustRate
-            } else if newValue > maxThrustRate {
-                _maxThrust = maxThrustRate
-            }
+            _maxThrust = min(max(newValue, minThrustRate), maxThrustRate)
         }
     }
     
@@ -226,11 +218,7 @@ final class Settings {
             return _yawRate
         }
         set {
-            if newValue < minYawRate {
-                _yawRate = minYawRate
-            } else if newValue > maxYawRate {
-                _yawRate = maxYawRate
-            }
+            _yawRate = min(max(newValue, minYawRate), maxYawRate)
         }
     }
 }

--- a/Crazyflie client/SettingsViewController.swift
+++ b/Crazyflie client/SettingsViewController.swift
@@ -67,12 +67,15 @@ final class SettingsViewController: UIViewController {
         
         if let pitch = viewModel.pitch {
             pitchrollSensitivity.text = String(describing: pitch)
+            pitchrollSensitivity.isEnabled = viewModel.canEditValues
         }
         if let thrust = viewModel.thrust {
             thrustSensitivity.text = String(describing: thrust)
+            thrustSensitivity.isEnabled = viewModel.canEditValues
         }
         if let yaw = viewModel.yaw {
             yawSensitivity.text = String(describing: yaw)
+            yawSensitivity.isEnabled = viewModel.canEditValues
         }
     }
     

--- a/Crazyflie client/SettingsViewController.swift
+++ b/Crazyflie client/SettingsViewController.swift
@@ -88,11 +88,23 @@ final class SettingsViewController: UIViewController {
     }
     
     @IBAction func closeClicked(_ sender: Any) {
+        if viewModel?.canEditValues == true {
+            [pitchrollSensitivity, thrustSensitivity, yawSensitivity].forEach { $0.resignFirstResponder() }
+        }
         dismiss(animated: true, completion: nil)
     }
     
     @IBAction func onBootloaderClicked( _ sender: Any) {
         viewModel?.bootloaderClicked()
+    }
+
+    @objc func endEditing(_ force: Bool) -> Bool {
+        guard viewModel?.canEditValues == true else { return false }
+        // Called only for sensitivity text fields
+        viewModel?.sensitivity.settings?.pitchRate = pitchrollSensitivity.text.flatMap(Float.init) ?? 0.0
+        viewModel?.sensitivity.settings?.maxThrust = thrustSensitivity.text.flatMap(Float.init) ?? 0.0
+        viewModel?.sensitivity.settings?.yawRate = yawSensitivity.text.flatMap(Float.init) ?? 0.0
+        return true
     }
 }
 


### PR DESCRIPTION
Fix settings for custom control sensitivities:
* make text fields for sensitivities editable only in custom mode
* store values in settings on end of editing or on scene dismissal

This fixes crash - issue #25.

Despite the fix makes sense for me, settings screen seems to be or partially broken or not well thought:
* I don't see even attempt to persist custom settings in the code. Is it a bug? Or design decision?
* It should be a button to cancel all changes and return to values as they were when settings screen was open.